### PR TITLE
Remove Async suffix from methods

### DIFF
--- a/src/Vlingo.Wire.Tests/Channel/MockChannelReader.cs
+++ b/src/Vlingo.Wire.Tests/Channel/MockChannelReader.cs
@@ -37,7 +37,7 @@ namespace Vlingo.Wire.Tests.Channel
             _consumer = consumer;
         }
 
-        public Task ProbeChannelAsync()
+        public Task ProbeChannel()
         {
             ProbeChannelCount.IncrementAndGet();
             

--- a/src/Vlingo.Wire.Tests/Channel/SocketChannelWriterTest.cs
+++ b/src/Vlingo.Wire.Tests/Channel/SocketChannelWriterTest.cs
@@ -39,18 +39,18 @@ namespace Vlingo.Wire.Tests.Channel
             
             var message1 = TestMessage + 1;
             var rawMessage1 = RawMessage.From(0, 0, message1);
-            await _channelWriter.WriteAsync(rawMessage1, buffer);
+            await _channelWriter.Write(rawMessage1, buffer);
             
-            await ProbeUntilConsumedAsync(_channelReader, consumer);
+            await ProbeUntilConsumed(_channelReader, consumer);
             
             Assert.Equal(1, consumer.ConsumeCount);
             Assert.Equal(message1, consumer.Messages.First());
             
             var message2 = TestMessage + 2;
             var rawMessage2 = RawMessage.From(0, 0, message2);
-            await _channelWriter.WriteAsync(rawMessage2, buffer);
+            await _channelWriter.Write(rawMessage2, buffer);
             
-            await ProbeUntilConsumedAsync(_channelReader, consumer);
+            await ProbeUntilConsumed(_channelReader, consumer);
             
             Assert.Equal(2, consumer.ConsumeCount);
             Assert.Equal(message2, consumer.Messages.Last());
@@ -74,13 +74,13 @@ namespace Vlingo.Wire.Tests.Channel
             _channelReader.Close();
         }
         
-        private async Task ProbeUntilConsumedAsync(IChannelReader reader, MockChannelReaderConsumer consumer)
+        private async Task ProbeUntilConsumed(IChannelReader reader, MockChannelReaderConsumer consumer)
         {
             var currentConsumedCount = consumer.ConsumeCount;
     
             for (int idx = 0; idx < 100; ++idx)
             {
-                await reader.ProbeChannelAsync();
+                await reader.ProbeChannel();
 
                 if (consumer.ConsumeCount > currentConsumedCount)
                 {

--- a/src/Vlingo.Wire.Tests/Fdx/Bidirectional/SocketRequestResponseChannelTest.cs
+++ b/src/Vlingo.Wire.Tests/Fdx/Bidirectional/SocketRequestResponseChannelTest.cs
@@ -57,7 +57,7 @@ namespace Vlingo.Wire.Tests.Fdx.Bidirectional
             
             while (_clientConsumer.UntilConsume.Remaining > 0)
             {
-                await _client.ProbeChannelAsync();
+                await _client.ProbeChannel();
             }
             _clientConsumer.UntilConsume.Completes();
             
@@ -92,7 +92,7 @@ namespace Vlingo.Wire.Tests.Fdx.Bidirectional
             while (_clientConsumer.UntilConsume.Remaining > 0)
             {
                 await Task.Delay(10);
-                await _client.ProbeChannelAsync();
+                await _client.ProbeChannel();
             }
             _clientConsumer.UntilConsume.Completes();
             
@@ -123,7 +123,7 @@ namespace Vlingo.Wire.Tests.Fdx.Bidirectional
             }
             
             while (_clientConsumer.UntilConsume.Remaining > 0) {
-                await _client.ProbeChannelAsync();
+                await _client.ProbeChannel();
             }
             
             _serverConsumer.UntilConsume.Completes();
@@ -159,7 +159,7 @@ namespace Vlingo.Wire.Tests.Fdx.Bidirectional
             }
     
             while (_clientConsumer.UntilConsume.Remaining > 0) {
-                await _client.ProbeChannelAsync();
+                await _client.ProbeChannel();
             }
             _serverConsumer.UntilConsume.Completes();
             _clientConsumer.UntilConsume.Completes();
@@ -231,7 +231,7 @@ namespace Vlingo.Wire.Tests.Fdx.Bidirectional
             _buffer.Clear();
             _buffer.Write(Converters.TextToBytes(request));
             _buffer.Flip();
-            await _client.RequestWithAsync(_buffer);
+            await _client.RequestWith(_buffer);
         }
     }
 }

--- a/src/Vlingo.Wire.Tests/Fdx/Inbound/InboundSocketChannelTest.cs
+++ b/src/Vlingo.Wire.Tests/Fdx/Inbound/InboundSocketChannelTest.cs
@@ -44,18 +44,18 @@ namespace Vlingo.Wire.Tests.Fdx.Inbound
             
             var message1 = _opMessage + 1;
             var rawMessage1 = RawMessage.From(0, 0, message1);
-            await _opChannel.WriteAsync(rawMessage1.AsStream(buffer));
+            await _opChannel.Write(rawMessage1.AsStream(buffer));
             
-            await ProbeUntilConsumedAsync(_opReader, consumer);
+            await ProbeUntilConsumed(_opReader, consumer);
             
             Assert.Equal(1, consumer.ConsumeCount);
             Assert.Equal(message1, consumer.Messages.First());
             
             var message2 = _opMessage + 2;
             var rawMessage2 = RawMessage.From(0, 0, message2);
-            await _opChannel.WriteAsync(rawMessage2.AsStream(buffer));
+            await _opChannel.Write(rawMessage2.AsStream(buffer));
             
-            await ProbeUntilConsumedAsync(_opReader, consumer);
+            await ProbeUntilConsumed(_opReader, consumer);
             
             Assert.Equal(2, consumer.ConsumeCount);
             Assert.Equal(message2, consumer.Messages.Last());
@@ -73,18 +73,18 @@ namespace Vlingo.Wire.Tests.Fdx.Inbound
             
             var message1 = _appMessage + 1;
             var rawMessage1 = RawMessage.From(0, 0, message1);
-            await _appChannel.WriteAsync(rawMessage1.AsStream(buffer));
+            await _appChannel.Write(rawMessage1.AsStream(buffer));
             
-            await ProbeUntilConsumedAsync(_appReader, consumer);
+            await ProbeUntilConsumed(_appReader, consumer);
             
             Assert.Equal(1, consumer.ConsumeCount);
             Assert.Equal(message1, consumer.Messages.First());
             
             var message2 = _appMessage + 2;
             var rawMessage2 = RawMessage.From(0, 0, message2);
-            await _appChannel.WriteAsync(rawMessage2.AsStream(buffer));
+            await _appChannel.Write(rawMessage2.AsStream(buffer));
             
-            await ProbeUntilConsumedAsync(_appReader, consumer);
+            await ProbeUntilConsumed(_appReader, consumer);
             
             Assert.Equal(2, consumer.ConsumeCount);
             Assert.Equal(message2, consumer.Messages.Last());
@@ -110,13 +110,13 @@ namespace Vlingo.Wire.Tests.Fdx.Inbound
             _opReader.Close();
         }
 
-        private async Task ProbeUntilConsumedAsync(IChannelReader reader, MockChannelReaderConsumer consumer)
+        private async Task ProbeUntilConsumed(IChannelReader reader, MockChannelReaderConsumer consumer)
         {
             var currentConsumedCount = consumer.ConsumeCount;
     
             for (int idx = 0; idx < 100; ++idx)
             {
-                await reader.ProbeChannelAsync();
+                await reader.ProbeChannel();
 
                 if (consumer.ConsumeCount > currentConsumedCount)
                 {

--- a/src/Vlingo.Wire.Tests/Fdx/Outbound/ManagedOutboundSocketChannelTest.cs
+++ b/src/Vlingo.Wire.Tests/Fdx/Outbound/ManagedOutboundSocketChannelTest.cs
@@ -45,18 +45,18 @@ namespace Vlingo.Wire.Tests.Fdx.Outbound
             
             var message1 = OpMessage + 1;
             var rawMessage1 = RawMessage.From(0, 0, message1);
-            await _opChannel.WriteAsync(rawMessage1.AsStream(buffer));
+            await _opChannel.Write(rawMessage1.AsStream(buffer));
             
-            await ProbeUntilConsumedAsync(_opReader, consumer);
+            await ProbeUntilConsumed(_opReader, consumer);
             
             Assert.Equal(1, consumer.ConsumeCount);
             Assert.Equal(message1, consumer.Messages.First());
             
             var message2 = OpMessage + 2;
             var rawMessage2 = RawMessage.From(0, 0, message2);
-            await _opChannel.WriteAsync(rawMessage2.AsStream(buffer));
+            await _opChannel.Write(rawMessage2.AsStream(buffer));
             
-            await ProbeUntilConsumedAsync(_opReader, consumer);
+            await ProbeUntilConsumed(_opReader, consumer);
             
             Assert.Equal(2, consumer.ConsumeCount);
             Assert.Equal(message2, consumer.Messages.Last());
@@ -74,18 +74,18 @@ namespace Vlingo.Wire.Tests.Fdx.Outbound
             
             var message1 = AppMessage + 1;
             var rawMessage1 = RawMessage.From(0, 0, message1);
-            await _appChannel.WriteAsync(rawMessage1.AsStream(buffer));
+            await _appChannel.Write(rawMessage1.AsStream(buffer));
             
-            await ProbeUntilConsumedAsync(_appReader, consumer);
+            await ProbeUntilConsumed(_appReader, consumer);
             
             Assert.Equal(1, consumer.ConsumeCount);
             Assert.Equal(message1, consumer.Messages.First());
             
             var message2 = AppMessage + 2;
             var rawMessage2 = RawMessage.From(0, 0, message2);
-            await _appChannel.WriteAsync(rawMessage2.AsStream(buffer));
+            await _appChannel.Write(rawMessage2.AsStream(buffer));
             
-            await ProbeUntilConsumedAsync(_appReader, consumer);
+            await ProbeUntilConsumed(_appReader, consumer);
             
             Assert.Equal(2, consumer.ConsumeCount);
             Assert.Equal(message2, consumer.Messages.Last());
@@ -111,13 +111,13 @@ namespace Vlingo.Wire.Tests.Fdx.Outbound
             _appReader.Close();
         }
         
-        private async Task ProbeUntilConsumedAsync(IChannelReader reader, MockChannelReaderConsumer consumer)
+        private async Task ProbeUntilConsumed(IChannelReader reader, MockChannelReaderConsumer consumer)
         {
             var currentConsumedCount = consumer.ConsumeCount;
     
             for (int idx = 0; idx < 100; ++idx)
             {
-                await reader.ProbeChannelAsync();
+                await reader.ProbeChannel();
 
                 if (consumer.ConsumeCount > currentConsumedCount)
                 {

--- a/src/Vlingo.Wire.Tests/Fdx/Outbound/MockManagedOutboundChannel.cs
+++ b/src/Vlingo.Wire.Tests/Fdx/Outbound/MockManagedOutboundChannel.cs
@@ -30,7 +30,7 @@ namespace Vlingo.Wire.Tests.Fdx.Outbound
             Writes.Clear();
         }
 
-        public Task WriteAsync(Stream buffer)
+        public Task Write(Stream buffer)
         {
             var message = RawMessage.ReadFromWithHeader(buffer);
             Writes.Add(message.AsTextMessage());

--- a/src/Vlingo.Wire.Tests/Fdx/Outbound/OutboundTest.cs
+++ b/src/Vlingo.Wire.Tests/Fdx/Outbound/OutboundTest.cs
@@ -36,9 +36,9 @@ namespace Vlingo.Wire.Tests.Fdx.Outbound
             var rawMessage2 = RawMessage.From(0, 0, Message2);
             var rawMessage3 = RawMessage.From(0, 0, Message3);
 
-            await _outbound.BroadcastAsync(rawMessage1);
-            await _outbound.BroadcastAsync(rawMessage2);
-            await _outbound.BroadcastAsync(rawMessage3);
+            await _outbound.Broadcast(rawMessage1);
+            await _outbound.Broadcast(rawMessage2);
+            await _outbound.Broadcast(rawMessage3);
 
             foreach (var channel in _channelProvider.AllOtherNodeChannels.Values)
             {
@@ -64,9 +64,9 @@ namespace Vlingo.Wire.Tests.Fdx.Outbound
             var rawMessage3 = RawMessage.From(0, 0, Message3);
             rawMessage3.AsBuffer((MemoryStream)buffer3.AsStream());
             
-            await _outbound.BroadcastAsync(buffer1);
-            await _outbound.BroadcastAsync(buffer2);
-            await _outbound.BroadcastAsync(buffer3);
+            await _outbound.Broadcast(buffer1);
+            await _outbound.Broadcast(buffer2);
+            await _outbound.Broadcast(buffer3);
             
             foreach (var channel in _channelProvider.AllOtherNodeChannels.Values)
             {
@@ -87,9 +87,9 @@ namespace Vlingo.Wire.Tests.Fdx.Outbound
 
             var selectNodes = new List<Node> {Config.NodeMatching(Id.Of(3))};
             
-            await _outbound.BroadcastAsync(selectNodes, rawMessage1);
-            await _outbound.BroadcastAsync(selectNodes, rawMessage2);
-            await _outbound.BroadcastAsync(selectNodes, rawMessage3);
+            await _outbound.Broadcast(selectNodes, rawMessage1);
+            await _outbound.Broadcast(selectNodes, rawMessage2);
+            await _outbound.Broadcast(selectNodes, rawMessage3);
             
             var mock = (MockManagedOutboundChannel) _channelProvider.ChannelFor(Id.Of(3));
             
@@ -107,9 +107,9 @@ namespace Vlingo.Wire.Tests.Fdx.Outbound
             
             var id3 = Id.Of(3);
             
-            await _outbound.SendToAsync(rawMessage1, id3);
-            await _outbound.SendToAsync(rawMessage2, id3);
-            await _outbound.SendToAsync(rawMessage3, id3);
+            await _outbound.SendTo(rawMessage1, id3);
+            await _outbound.SendTo(rawMessage2, id3);
+            await _outbound.SendTo(rawMessage3, id3);
             
             var mock = (MockManagedOutboundChannel)_channelProvider.ChannelFor(Id.Of(3));
             
@@ -134,9 +134,9 @@ namespace Vlingo.Wire.Tests.Fdx.Outbound
             
             var id3 = Id.Of(3);
             
-            await _outbound.SendToAsync(buffer1, id3);
-            await _outbound.SendToAsync(buffer2, id3);
-            await _outbound.SendToAsync(buffer3, id3);
+            await _outbound.SendTo(buffer1, id3);
+            await _outbound.SendTo(buffer2, id3);
+            await _outbound.SendTo(buffer3, id3);
             
             var mock = (MockManagedOutboundChannel)_channelProvider.ChannelFor(Id.Of(3));
             

--- a/src/Vlingo.Wire.Tests/Multicast/MulticastTest.cs
+++ b/src/Vlingo.Wire.Tests/Multicast/MulticastTest.cs
@@ -45,11 +45,11 @@ namespace Vlingo.Wire.Tests.Multicast
                 publisher.SendAvailability();
             }
             
-            await publisher.ProcessChannelAsync();
+            await publisher.ProcessChannel();
     
             for (int i = 0; i < 2; ++i)
             {
-                await subscriber.ProbeChannelAsync();
+                await subscriber.ProbeChannel();
             }
     
             Assert.Equal(0, publisherConsumer.ConsumeCount);

--- a/src/Vlingo.Wire/Channel/IChannelPublisher.cs
+++ b/src/Vlingo.Wire/Channel/IChannelPublisher.cs
@@ -13,7 +13,7 @@ namespace Vlingo.Wire.Channel
     public interface IChannelPublisher
     {
         void Close();
-        Task ProcessChannelAsync();
+        Task ProcessChannel();
         void SendAvailability();
         void Send(RawMessage message);
     }

--- a/src/Vlingo.Wire/Channel/IChannelReader.cs
+++ b/src/Vlingo.Wire/Channel/IChannelReader.cs
@@ -14,6 +14,6 @@ namespace Vlingo.Wire.Channel
         void Close();
         string Name { get; }
         void OpenFor(IChannelReaderConsumer consumer);
-        Task ProbeChannelAsync();
+        Task ProbeChannel();
     }
 }

--- a/src/Vlingo.Wire/Channel/IRequestSenderChannel.cs
+++ b/src/Vlingo.Wire/Channel/IRequestSenderChannel.cs
@@ -14,6 +14,6 @@ namespace Vlingo.Wire.Channel
     {
         void Close();
         
-        Task RequestWithAsync(Stream stream);
+        Task RequestWith(Stream stream);
     }
 }

--- a/src/Vlingo.Wire/Channel/IResponseListenerChannel.cs
+++ b/src/Vlingo.Wire/Channel/IResponseListenerChannel.cs
@@ -11,6 +11,6 @@ namespace Vlingo.Wire.Channel
 {
     public interface IResponseListenerChannel
     {
-        Task ProbeChannelAsync();
+        Task ProbeChannel();
     }
 }

--- a/src/Vlingo.Wire/Channel/ISocketChannelSelectionProcessor.cs
+++ b/src/Vlingo.Wire/Channel/ISocketChannelSelectionProcessor.cs
@@ -14,6 +14,6 @@ namespace Vlingo.Wire.Channel
     {
         void Close();
         
-        Task ProcessAsync(Socket channel);
+        Task Process(Socket channel);
     }
 }

--- a/src/Vlingo.Wire/Channel/SelectionReader.cs
+++ b/src/Vlingo.Wire/Channel/SelectionReader.cs
@@ -20,7 +20,7 @@ namespace Vlingo.Wire.Channel
             Dispatcher = dispatcher;
         }
 
-        public abstract Task ReadAsync(Socket channel, RawMessageBuilder builder);
+        public abstract Task Read(Socket channel, RawMessageBuilder builder);
 
         protected void CloseClientResources(Socket socket)
         {

--- a/src/Vlingo.Wire/Channel/SocketChannelSelectionProcessorActor.cs
+++ b/src/Vlingo.Wire/Channel/SocketChannelSelectionProcessorActor.cs
@@ -68,7 +68,7 @@ namespace Vlingo.Wire.Channel
         // SocketChannelSelectionProcessor
         //=========================================
         
-        public async Task ProcessAsync(Socket channel)
+        public async Task Process(Socket channel)
         {
             try
             {
@@ -95,13 +95,13 @@ namespace Vlingo.Wire.Channel
             try
             {
                 // this is invoked in the context of another Thread so even if we can block here
-                ProbeChannelAsync().Wait();
+                ProbeChannel().Wait();
             }
             catch (AggregateException ae)
             {
                 foreach (var e in ae.InnerExceptions)
                 {
-                    Logger.Log($"Failed to ProbeChannelAsync for {_name} because: {e.Message}", e);
+                    Logger.Log($"Failed to ProbeChannel for {_name} because: {e.Message}", e);
                 }
                 
                 throw ae.Flatten();
@@ -151,7 +151,7 @@ namespace Vlingo.Wire.Channel
             }
         }
 
-        private async Task ProbeChannelAsync()
+        private async Task ProbeChannel()
         {
             if (IsStopped)
             {
@@ -164,11 +164,11 @@ namespace Vlingo.Wire.Channel
                 {
                     if (_context.Channel.Available > 0)
                     {
-                        await ReadAsync(_context);
+                        await Read(_context);
                     }
                     else
                     {
-                        await WriteAsync(_context);
+                        await Write(_context);
                     }
                 }
             }
@@ -178,7 +178,7 @@ namespace Vlingo.Wire.Channel
             }
         }
         
-        private async Task ReadAsync(Context readable)
+        private async Task Read(Context readable)
         {
             var channel = readable.Channel;
             if (!channel.IsSocketConnected())
@@ -224,7 +224,7 @@ namespace Vlingo.Wire.Channel
             }
         }
 
-        private async Task WriteAsync(Context writable)
+        private async Task Write(Context writable)
         {
             var channel = writable.Channel;
             if (!channel.IsSocketConnected())
@@ -236,19 +236,19 @@ namespace Vlingo.Wire.Channel
             
             if (writable.HasNextWritable)
             {
-                await WriteWithCachedDataAsync(writable, channel);
+                await WriteWithCachedData(writable, channel);
             }
         }
 
-        private async Task WriteWithCachedDataAsync(Context context, Socket channel)
+        private async Task WriteWithCachedData(Context context, Socket channel)
         {
             for (var buffer = context.NextWritable(); buffer != null; buffer = context.NextWritable())
             {
-                await WriteWithCachedDataAsync(context, channel, buffer);
+                await WriteWithCachedData(context, channel, buffer);
             }
         }
 
-        private async Task WriteWithCachedDataAsync(Context context, Socket clientChannel, IConsumerByteBuffer buffer)
+        private async Task WriteWithCachedData(Context context, Socket clientChannel, IConsumerByteBuffer buffer)
         {
             try
             {

--- a/src/Vlingo.Wire/Channel/SocketChannelSelectionProcessor__Proxy.cs
+++ b/src/Vlingo.Wire/Channel/SocketChannelSelectionProcessor__Proxy.cs
@@ -8,7 +8,7 @@ namespace Vlingo.Wire.Channel
     public class SocketChannelSelectionProcessor__Proxy : ISocketChannelSelectionProcessor
     {
         private const string CloseRepresentation1 = "Close()";
-        private const string ProcessAsyncRepresentation2 = "ProcessAsync(Socket)";
+        private const string ProcessRepresentation2 = "Process(Socket)";
 
         private readonly Actor actor;
         private readonly IMailbox mailbox;
@@ -40,25 +40,25 @@ namespace Vlingo.Wire.Channel
             }
         }
 
-        public Task ProcessAsync(Socket channel)
+        public Task Process(Socket channel)
         {
             if (!actor.IsStopped)
             {
-                Action<ISocketChannelSelectionProcessor> consumer = x => x.ProcessAsync(channel).Wait();
+                Action<ISocketChannelSelectionProcessor> consumer = x => x.Process(channel).Wait();
                 if (mailbox.IsPreallocated)
                 {
-                    mailbox.Send(actor, consumer, null, ProcessAsyncRepresentation2);
+                    mailbox.Send(actor, consumer, null, ProcessRepresentation2);
                 }
                 else
                 {
                     mailbox.Send(
                         new LocalMessage<ISocketChannelSelectionProcessor>(actor, consumer,
-                            ProcessAsyncRepresentation2));
+                            ProcessRepresentation2));
                 }
             }
             else
             {
-                actor.DeadLetters.FailedDelivery(new DeadLetter(actor, ProcessAsyncRepresentation2));
+                actor.DeadLetters.FailedDelivery(new DeadLetter(actor, ProcessRepresentation2));
             }
 
             return Task.CompletedTask;

--- a/src/Vlingo.Wire/Channel/SocketChannelSelectionReader.cs
+++ b/src/Vlingo.Wire/Channel/SocketChannelSelectionReader.cs
@@ -17,7 +17,7 @@ namespace Vlingo.Wire.Channel
         {
         }
 
-        public override async Task ReadAsync(Socket channel, RawMessageBuilder builder)
+        public override async Task Read(Socket channel, RawMessageBuilder builder)
         {
             var bytesRead = 0;
             var totalBytesRead = 0;

--- a/src/Vlingo.Wire/Channel/SocketChannelWriter.cs
+++ b/src/Vlingo.Wire/Channel/SocketChannelWriter.cs
@@ -45,17 +45,17 @@ namespace Vlingo.Wire.Channel
             _channel = null;
         }
 
-        public async Task<int> WriteAsync(RawMessage message, MemoryStream buffer)
+        public async Task<int> Write(RawMessage message, MemoryStream buffer)
         {
             buffer.Clear();
             message.CopyBytesTo(buffer);
             buffer.Flip();
-            return await WriteAsync(buffer);
+            return await Write(buffer);
         }
 
-        public async Task<int> WriteAsync(MemoryStream buffer)
+        public async Task<int> Write(MemoryStream buffer)
         {
-            var preparedChannel = await PreparedChannelAsync();
+            var preparedChannel = await PreparedChannel();
             var totalBytesWritten = 0;
             try
             {
@@ -77,7 +77,7 @@ namespace Vlingo.Wire.Channel
 
         public override string ToString() => $"SocketChannelWriter[address={_address}, channel={_channel}]";
 
-        private async Task<Socket> PreparedChannelAsync()
+        private async Task<Socket> PreparedChannel()
         {
             try
             {

--- a/src/Vlingo.Wire/Fdx/Bidirectional/ClientRequestResponseChannel.cs
+++ b/src/Vlingo.Wire/Fdx/Bidirectional/ClientRequestResponseChannel.cs
@@ -58,9 +58,9 @@ namespace Vlingo.Wire.Fdx.Bidirectional
             CloseChannel();
         }
 
-        public async Task RequestWithAsync(Stream stream)
+        public async Task RequestWith(Stream stream)
         {
-            var preparedChannel = await PreparedChannelAsync();
+            var preparedChannel = await PreparedChannel();
             if (preparedChannel != null)
             {
                 try
@@ -84,7 +84,7 @@ namespace Vlingo.Wire.Fdx.Bidirectional
         // ResponseListenerChannel
         //=========================================
 
-        public async Task ProbeChannelAsync()
+        public async Task ProbeChannel()
         {
             if (_closed)
             {
@@ -93,10 +93,10 @@ namespace Vlingo.Wire.Fdx.Bidirectional
 
             try
             {
-                var channel = await PreparedChannelAsync();
+                var channel = await PreparedChannel();
                 if (channel != null)
                 {
-                    await ReadConsumeAsync(channel);
+                    await ReadConsume(channel);
                 }
             }
             catch (Exception e)
@@ -126,7 +126,7 @@ namespace Vlingo.Wire.Fdx.Bidirectional
             _channel = null;
         }
 
-        private async Task<Socket> PreparedChannelAsync()
+        private async Task<Socket> PreparedChannel()
         {
             try
             {
@@ -165,7 +165,7 @@ namespace Vlingo.Wire.Fdx.Bidirectional
             return null;
         }
 
-        private async Task ReadConsumeAsync(Socket channel)
+        private async Task ReadConsume(Socket channel)
         {
             var pooledBuffer = _readBufferPool.AccessFor("client-response", 25);
             var readBuffer = pooledBuffer.ToArray();

--- a/src/Vlingo.Wire/Fdx/Bidirectional/ClientRequestResponseChannelPipeline.cs
+++ b/src/Vlingo.Wire/Fdx/Bidirectional/ClientRequestResponseChannelPipeline.cs
@@ -55,9 +55,9 @@ namespace Vlingo.Wire.Fdx.Bidirectional
             CloseChannel();
         }
 
-        public async Task RequestWithAsync(Stream stream)
+        public async Task RequestWith(Stream stream)
         {
-            var preparedChannel = await PreparedChannelAsync();
+            var preparedChannel = await PreparedChannel();
             if (preparedChannel != null)
             {
                 try
@@ -82,7 +82,7 @@ namespace Vlingo.Wire.Fdx.Bidirectional
         // ResponseListenerChannel
         //=========================================
 
-        public async Task ProbeChannelAsync()
+        public async Task ProbeChannel()
         {
             if (_closed)
             {
@@ -91,12 +91,12 @@ namespace Vlingo.Wire.Fdx.Bidirectional
 
             try
             {
-                var channel = await PreparedChannelAsync();
+                var channel = await PreparedChannel();
                 if (channel != null)
                 {
                     var pipe = new Pipe();
-                    var input = ReadConsumeAsync(channel, pipe.Writer);
-                    var output = WriteConsumeAsync(pipe.Reader);
+                    var input = ReadConsume(channel, pipe.Writer);
+                    var output = WriteConsume(pipe.Reader);
                     await Task.WhenAll(input, output);
                 }
             }
@@ -127,7 +127,7 @@ namespace Vlingo.Wire.Fdx.Bidirectional
             _channel = null;
         }
 
-        private async Task<Socket> PreparedChannelAsync()
+        private async Task<Socket> PreparedChannel()
         {
             try
             {
@@ -167,7 +167,7 @@ namespace Vlingo.Wire.Fdx.Bidirectional
             return null;
         }
 
-        private async Task ReadConsumeAsync(Socket channel, PipeWriter writer)
+        private async Task ReadConsume(Socket channel, PipeWriter writer)
         {
             const int minimumBufferSize = 512;
             while (true)
@@ -203,7 +203,7 @@ namespace Vlingo.Wire.Fdx.Bidirectional
             writer.Complete();
         }
 
-        private async Task WriteConsumeAsync(PipeReader reader)
+        private async Task WriteConsume(PipeReader reader)
         {
             while (true)
             {

--- a/src/Vlingo.Wire/Fdx/Bidirectional/ServerRequestResponseChannelActor.cs
+++ b/src/Vlingo.Wire/Fdx/Bidirectional/ServerRequestResponseChannelActor.cs
@@ -104,7 +104,7 @@ namespace Vlingo.Wire.Fdx.Bidirectional
         public void IntervalSignal(IScheduled<object> scheduled, object data)
         {
             // this is invoked in the context of another Thread so even if we can block here
-            ProbeChannelAsync().Wait();
+            ProbeChannel().Wait();
         }
         
         //=========================================
@@ -135,7 +135,7 @@ namespace Vlingo.Wire.Fdx.Bidirectional
         //=========================================
         // internal implementation
         //=========================================
-        private async Task ProbeChannelAsync()
+        private async Task ProbeChannel()
         {
             if (IsStopped)
             {
@@ -144,7 +144,7 @@ namespace Vlingo.Wire.Fdx.Bidirectional
 
             try
             {
-                await AcceptAsync(_channel);
+                await Accept(_channel);
             }
             catch (Exception e)
             {
@@ -152,9 +152,9 @@ namespace Vlingo.Wire.Fdx.Bidirectional
             }
         }
 
-        private async Task AcceptAsync(Socket channel)
+        private async Task Accept(Socket channel)
         {
-            await PooledProcessor().ProcessAsync(channel);
+            await PooledProcessor().Process(channel);
         }
 
         private ISocketChannelSelectionProcessor PooledProcessor()

--- a/src/Vlingo.Wire/Fdx/Inbound/InboundStreamActor.cs
+++ b/src/Vlingo.Wire/Fdx/Inbound/InboundStreamActor.cs
@@ -41,7 +41,7 @@ namespace Vlingo.Wire.Fdx.Inbound
         
         public void IntervalSignal(IScheduled<object> scheduled, object data)
         {
-            _reader.ProbeChannelAsync().Wait();
+            _reader.ProbeChannel().Wait();
         }
         
         //=========================================

--- a/src/Vlingo.Wire/Fdx/Inbound/SocketChannelInboundReader.cs
+++ b/src/Vlingo.Wire/Fdx/Inbound/SocketChannelInboundReader.cs
@@ -76,19 +76,19 @@ namespace Vlingo.Wire.Fdx.Inbound
             _channel.Listen(120);
         }
 
-        public async Task ProbeChannelAsync()
+        public async Task ProbeChannel()
         {
             try
             {
                 if (_clientChannel == null)
                 {
-                    _clientChannel = await AcceptAsync(_channel);
+                    _clientChannel = await Accept(_channel);
                 }
                 else
                 {
                     if (_clientChannel.Available > 0)
                     {
-                        await new SocketChannelSelectionReader(this).ReadAsync(_clientChannel, new RawMessageBuilder(_maxMessageSize));
+                        await new SocketChannelSelectionReader(this).Read(_clientChannel, new RawMessageBuilder(_maxMessageSize));
                     }
                 }
             }
@@ -131,7 +131,7 @@ namespace Vlingo.Wire.Fdx.Inbound
         // internal implementation
         //=========================================
         
-        private async Task<Socket> AcceptAsync(Socket channel)
+        private async Task<Socket> Accept(Socket channel)
         {
             try
             {

--- a/src/Vlingo.Wire/Fdx/Outbound/ApplicationOutboundStreamActor.cs
+++ b/src/Vlingo.Wire/Fdx/Outbound/ApplicationOutboundStreamActor.cs
@@ -24,9 +24,9 @@ namespace Vlingo.Wire.Fdx.Outbound
         // ClusterApplicationOutboundStream
         //===================================
 
-        public void Broadcast(RawMessage message) => _outbound.BroadcastAsync(message).Wait();
+        public void Broadcast(RawMessage message) => _outbound.Broadcast(message).Wait();
 
-        public void SendTo(RawMessage message, Id targetId) => _outbound.SendToAsync(message, targetId).Wait();
+        public void SendTo(RawMessage message, Id targetId) => _outbound.SendTo(message, targetId).Wait();
         
         //===================================
         // Stoppable

--- a/src/Vlingo.Wire/Fdx/Outbound/IManagedOutboundChannel.cs
+++ b/src/Vlingo.Wire/Fdx/Outbound/IManagedOutboundChannel.cs
@@ -14,6 +14,6 @@ namespace Vlingo.Wire.Fdx.Outbound
     {
         void Close();
 
-        Task WriteAsync(Stream buffer);
+        Task Write(Stream buffer);
     }
 }

--- a/src/Vlingo.Wire/Fdx/Outbound/ManagedOutboundSocketChannel.cs
+++ b/src/Vlingo.Wire/Fdx/Outbound/ManagedOutboundSocketChannel.cs
@@ -47,9 +47,9 @@ namespace Vlingo.Wire.Fdx.Outbound
             }
         }
 
-        public async Task WriteAsync(Stream buffer)
+        public async Task Write(Stream buffer)
         {
-            var preparedChannel = await PreparedChannelAsync();
+            var preparedChannel = await PreparedChannel();
             try
             {
                 while (buffer.HasRemaining())
@@ -87,7 +87,7 @@ namespace Vlingo.Wire.Fdx.Outbound
             _disposed = true;
         }
         
-        private async Task<Socket> PreparedChannelAsync()
+        private async Task<Socket> PreparedChannel()
         {
             try
             {

--- a/src/Vlingo.Wire/Fdx/Outbound/Outbound.cs
+++ b/src/Vlingo.Wire/Fdx/Outbound/Outbound.cs
@@ -24,28 +24,28 @@ namespace Vlingo.Wire.Fdx.Outbound
             _pool = byteBufferPool;
         }
 
-        public async Task BroadcastAsync(RawMessage message)
+        public async Task Broadcast(RawMessage message)
         {
             var buffer = _pool.Access();
-            await BroadcastAsync(BytesFrom(message, buffer));
+            await Broadcast(BytesFrom(message, buffer));
         }
 
-        public async Task BroadcastAsync(IConsumerByteBuffer buffer)
+        public async Task Broadcast(IConsumerByteBuffer buffer)
         {
             // currently based on configured nodes,
             // but eventually could be live-node based
-            await BroadcastAsync(_provider.AllOtherNodeChannels, buffer);
+            await Broadcast(_provider.AllOtherNodeChannels, buffer);
         }
 
-        public async Task BroadcastAsync(IEnumerable<Node> selectNodes, RawMessage message)
+        public async Task Broadcast(IEnumerable<Node> selectNodes, RawMessage message)
         {
             var buffer = _pool.Access();
-            await BroadcastAsync(selectNodes, BytesFrom(message, buffer));
+            await Broadcast(selectNodes, BytesFrom(message, buffer));
         }
 
-        public async Task BroadcastAsync(IEnumerable<Node> selectNodes, IConsumerByteBuffer buffer)
+        public async Task Broadcast(IEnumerable<Node> selectNodes, IConsumerByteBuffer buffer)
         {
-            await BroadcastAsync(_provider.ChannelsFor(selectNodes), buffer);
+            await Broadcast(_provider.ChannelsFor(selectNodes), buffer);
         }
 
         public IConsumerByteBuffer BytesFrom(RawMessage message, IConsumerByteBuffer buffer)
@@ -62,18 +62,18 @@ namespace Vlingo.Wire.Fdx.Outbound
 
         public ByteBufferPool.PooledByteBuffer PooledByteBuffer() => _pool.Access();
 
-        public async Task SendToAsync(RawMessage message, Id id)
+        public async Task SendTo(RawMessage message, Id id)
         {
             var buffer = _pool.Access();
-            await SendToAsync(BytesFrom(message, buffer), id);
+            await SendTo(BytesFrom(message, buffer), id);
         }
 
-        public async Task SendToAsync(IConsumerByteBuffer buffer, Id id)
+        public async Task SendTo(IConsumerByteBuffer buffer, Id id)
         {
             try 
             {
                 Open(id);
-                await _provider.ChannelFor(id).WriteAsync(buffer.AsStream());
+                await _provider.ChannelFor(id).Write(buffer.AsStream());
             }
             finally
             {
@@ -81,7 +81,7 @@ namespace Vlingo.Wire.Fdx.Outbound
             }
         }
 
-        private async Task BroadcastAsync(IReadOnlyDictionary<Id, IManagedOutboundChannel> channels, IConsumerByteBuffer buffer)
+        private async Task Broadcast(IReadOnlyDictionary<Id, IManagedOutboundChannel> channels, IConsumerByteBuffer buffer)
         {
             try
             {
@@ -89,7 +89,7 @@ namespace Vlingo.Wire.Fdx.Outbound
                 foreach (var channel in channels.Values)
                 {
                     bufferToWrite.Position = 0;
-                    await channel.WriteAsync(bufferToWrite);
+                    await channel.Write(bufferToWrite);
                 }
             }
             finally

--- a/src/Vlingo.Wire/Multicast/MulticastPublisherReader.cs
+++ b/src/Vlingo.Wire/Multicast/MulticastPublisherReader.cs
@@ -98,7 +98,7 @@ namespace Vlingo.Wire.Multicast
             }
         }
 
-        public async Task ProcessChannelAsync()
+        public async Task ProcessChannel()
         {
             // TODO: This part lack Accept and read like in java version
             if (_closed)
@@ -108,7 +108,7 @@ namespace Vlingo.Wire.Multicast
 
             try
             {
-                await SendMaxAsync();
+                await SendMax();
             }
             catch (SocketException e)
             {
@@ -197,7 +197,7 @@ namespace Vlingo.Wire.Multicast
             }
         }
 
-        private async Task SendMaxAsync()
+        private async Task SendMax()
         {
             while (true)
             {

--- a/src/Vlingo.Wire/Multicast/MulticastSubscriber.cs
+++ b/src/Vlingo.Wire/Multicast/MulticastSubscriber.cs
@@ -118,7 +118,7 @@ namespace Vlingo.Wire.Multicast
             _consumer = consumer;
         }
 
-        public async Task ProbeChannelAsync()
+        public async Task ProbeChannel()
         {
             if (_closed)
             {

--- a/src/Vlingo.Wire/Vlingo.Wire.csproj
+++ b/src/Vlingo.Wire/Vlingo.Wire.csproj
@@ -6,7 +6,7 @@
 
     <!-- NuGet Metadata -->
     <IsPackable>true</IsPackable>
-    <PackageVersion>0.2.2</PackageVersion>
+    <PackageVersion>0.3.2</PackageVersion>
     <PackageId>Vlingo.Wire</PackageId>
     <Authors>Vlingo</Authors>
     <Description>


### PR DESCRIPTION
Remove Async suffix from methods because it' kind of leaky abstraction especially when defined on interfaces. Also it sticks to contracts defined in Java version.
Bump version