### PR TITLE
Ensure that only non zero bytes are returned from RawMessage as buffer.

### DIFF
--- a/src/Vlingo.Wire/Message/RawMessage.cs
+++ b/src/Vlingo.Wire/Message/RawMessage.cs
@@ -109,7 +109,7 @@ namespace Vlingo.Wire.Message
         public byte[] AsBuffer(MemoryStream buffer)
         {
             var s = (MemoryStream)AsStream(buffer);
-            return s.GetBuffer();
+            return s.ToArray();
         }
 
         public string AsTextMessage() => Converters.BytesToText(_bytes, 0, (int)Length);

--- a/src/Vlingo.Wire/Vlingo.Wire.csproj
+++ b/src/Vlingo.Wire/Vlingo.Wire.csproj
@@ -6,7 +6,7 @@
 
     <!-- NuGet Metadata -->
     <IsPackable>true</IsPackable>
-    <PackageVersion>0.3.6</PackageVersion>
+    <PackageVersion>0.3.7</PackageVersion>
     <PackageId>Vlingo.Wire</PackageId>
     <Authors>Vlingo</Authors>
     <Description>


### PR DESCRIPTION
This causes bad message deserialization on the receiving end