### PR TITLE
MulticastSubscriber fix on message build before sending to consumer.

### DIFF
--- a/src/Vlingo.Wire/Multicast/MulticastSubscriber.cs
+++ b/src/Vlingo.Wire/Multicast/MulticastSubscriber.cs
@@ -145,7 +145,7 @@ namespace Vlingo.Wire.Multicast
                         
                         if (received.ReceivedBytes > 0)
                         {
-                            _buffer.Write(bytes, 0, bytes.Length);
+                            _buffer.Write(bytes, 0, received.ReceivedBytes);
                             _buffer.Flip();
                             _message.From(_buffer);
                         

--- a/src/Vlingo.Wire/Vlingo.Wire.csproj
+++ b/src/Vlingo.Wire/Vlingo.Wire.csproj
@@ -6,7 +6,7 @@
 
     <!-- NuGet Metadata -->
     <IsPackable>true</IsPackable>
-    <PackageVersion>0.3.7</PackageVersion>
+    <PackageVersion>0.3.8</PackageVersion>
     <PackageId>Vlingo.Wire</PackageId>
     <Authors>Vlingo</Authors>
     <Description>


### PR DESCRIPTION
MulticastSubscriber should write to the buffer the length of the received bytes length and not max message size. related to #29 

Bump version