### PR TITLE
Wrong host name resolution for loopback

### DIFF
--- a/src/Vlingo.Wire/Multicast/MulticastPublisherReader.cs
+++ b/src/Vlingo.Wire/Multicast/MulticastPublisherReader.cs
@@ -193,6 +193,11 @@ namespace Vlingo.Wire.Multicast
             }
             catch
             {
+                if (publisherAddress.ToString().StartsWith("::"))
+                {
+                    return "localhost";
+                }
+                
                 return publisherAddress.ToString();
             }
         }

--- a/src/Vlingo.Wire/Vlingo.Wire.csproj
+++ b/src/Vlingo.Wire/Vlingo.Wire.csproj
@@ -6,7 +6,7 @@
 
     <!-- NuGet Metadata -->
     <IsPackable>true</IsPackable>
-    <PackageVersion>0.3.8</PackageVersion>
+    <PackageVersion>0.3.9</PackageVersion>
     <PackageId>Vlingo.Wire</PackageId>
     <Authors>Vlingo</Authors>
     <Description>


### PR DESCRIPTION
MulticastPublisherReader should return "localhost" on name resolution for "::" loopback address