### PR TITLE
Implement read channel in MulticastPublisherReader

### DIFF
--- a/src/Vlingo.Wire/Channel/SocketChannelWriter.cs
+++ b/src/Vlingo.Wire/Channel/SocketChannelWriter.cs
@@ -55,7 +55,7 @@ namespace Vlingo.Wire.Channel
 
         public async Task<int> Write(MemoryStream buffer)
         {
-            var preparedChannel = await PreparedChannel();
+            _channel = await PreparedChannel();
             var totalBytesWritten = 0;
             try
             {
@@ -63,7 +63,7 @@ namespace Vlingo.Wire.Channel
                 {
                     var bytes = new byte[buffer.Length];
                     await buffer.ReadAsync(bytes, 0, bytes.Length);
-                    totalBytesWritten += await preparedChannel.SendAsync(new ArraySegment<byte>(bytes), SocketFlags.None);
+                    totalBytesWritten += await _channel.SendAsync(new ArraySegment<byte>(bytes), SocketFlags.None);
                 }
             }
             catch (Exception e)
@@ -92,9 +92,9 @@ namespace Vlingo.Wire.Channel
                 }
                 else
                 {
-                    _channel = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp);
-                    await _channel.ConnectAsync(_address.HostName, _address.Port);
-                    return _channel;
+                    var channel = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp);
+                    await channel.ConnectAsync(_address.HostName, _address.Port);
+                    return channel;
                 }
             }
             catch (Exception e)

--- a/src/Vlingo.Wire/Vlingo.Wire.csproj
+++ b/src/Vlingo.Wire/Vlingo.Wire.csproj
@@ -6,7 +6,7 @@
 
     <!-- NuGet Metadata -->
     <IsPackable>true</IsPackable>
-    <PackageVersion>0.3.9</PackageVersion>
+    <PackageVersion>0.3.10</PackageVersion>
     <PackageId>Vlingo.Wire</PackageId>
     <Authors>Vlingo</Authors>
     <Description>


### PR DESCRIPTION
Fix #32. read channel in `MulticastPublisherReader` is used by the directory to send registration messages. It was a lacking implementation.