### PR TITLE
Fix NullReferenceException in MulticastPublisherReader

### DIFF
--- a/src/Vlingo.Wire/Multicast/MulticastPublisherReader.cs
+++ b/src/Vlingo.Wire/Multicast/MulticastPublisherReader.cs
@@ -181,7 +181,7 @@ namespace Vlingo.Wire.Multicast
                     _clientReadChannel = await Accept(_readChannel);
                 }
                 
-                if (_clientReadChannel.Available > 0)
+                if (_clientReadChannel != null && _clientReadChannel.Available > 0)
                 {
                     await new SocketChannelSelectionReader(this).Read(_clientReadChannel, new RawMessageBuilder(_messageBuffer.Capacity));
                 }

--- a/src/Vlingo.Wire/Vlingo.Wire.csproj
+++ b/src/Vlingo.Wire/Vlingo.Wire.csproj
@@ -25,7 +25,7 @@
     </AssemblyAttribute>
   </ItemGroup>
   <ItemGroup>
-    <None Include="..\..\LICENSE" Pack="true" PackagePath="" />
+    <None Include="..\..\LICENSE" />
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="System.IO.Pipelines" Version="4.5.3" />

--- a/src/Vlingo.Wire/Vlingo.Wire.csproj
+++ b/src/Vlingo.Wire/Vlingo.Wire.csproj
@@ -25,7 +25,7 @@
     </AssemblyAttribute>
   </ItemGroup>
   <ItemGroup>
-    <None Include="..\..\LICENSE" />
+    <None Include="..\..\LICENSE" Pack="true" PackagePath="" />
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="System.IO.Pipelines" Version="4.5.3" />

--- a/src/Vlingo.Wire/Vlingo.Wire.csproj
+++ b/src/Vlingo.Wire/Vlingo.Wire.csproj
@@ -6,7 +6,7 @@
 
     <!-- NuGet Metadata -->
     <IsPackable>true</IsPackable>
-    <PackageVersion>0.3.10</PackageVersion>
+    <PackageVersion>0.3.11</PackageVersion>
     <PackageId>Vlingo.Wire</PackageId>
     <Authors>Vlingo</Authors>
     <Description>


### PR DESCRIPTION
It occurs when accept returns a null socket.