### PR TITLE
Allows accepting multiple connections on read channel

### DIFF
--- a/src/Vlingo.Wire.Tests/Multicast/MulticastTest.cs
+++ b/src/Vlingo.Wire.Tests/Multicast/MulticastTest.cs
@@ -85,6 +85,51 @@ namespace Vlingo.Wire.Tests.Multicast
             
             Assert.Equal(1, publisherConsumer.ConsumeCount);
         }
+        
+        [Fact]
+        public async Task TestPublisherChannelReaderWithMultipleClients()
+        {
+            var publisherConsumer = new MockChannelReaderConsumer();
+
+            var publisher = new MulticastPublisherReader(
+                "test-publisher",
+                new Group("237.37.37.2", 37391),
+                37399,
+                1024,
+                publisherConsumer,
+                ConsoleLogger.TestInstance());
+            
+            var client1 = new SocketChannelWriter(
+                Address.From(
+                    Host.Of("localhost"), 
+                    37399, 
+                    AddressType.Main),
+                ConsoleLogger.TestInstance());
+            
+            var client2 = new SocketChannelWriter(
+                Address.From(
+                    Host.Of("localhost"), 
+                    37399, 
+                    AddressType.Main),
+                ConsoleLogger.TestInstance());
+            
+            var client3 = new SocketChannelWriter(
+                Address.From(
+                    Host.Of("localhost"), 
+                    37399, 
+                    AddressType.Main),
+                ConsoleLogger.TestInstance());
+
+            await client1.Write(RawMessage.From(1, 1, "test-response1"), new MemoryStream());
+            await client2.Write(RawMessage.From(1, 1, "test-response2"), new MemoryStream());
+            await client3.Write(RawMessage.From(1, 1, "test-response3"), new MemoryStream());
+            
+            await publisher.ProbeChannel();
+            await publisher.ProbeChannel();
+            await publisher.ProbeChannel();
+
+            Assert.Equal(3, publisherConsumer.ConsumeCount);
+        }
 
         public MulticastTest(ITestOutputHelper output)
         {

--- a/src/Vlingo.Wire/Multicast/MulticastPublisherReader.cs
+++ b/src/Vlingo.Wire/Multicast/MulticastPublisherReader.cs
@@ -30,7 +30,6 @@ namespace Vlingo.Wire.Multicast
         private readonly string _name;
         private readonly IPEndPoint _publisherAddress;
         private readonly Socket _readChannel;
-        private Socket _clientReadChannel;
         private bool _disposed;
 
         public MulticastPublisherReader(
@@ -176,14 +175,11 @@ namespace Vlingo.Wire.Multicast
         {
             try
             {
-                if (_clientReadChannel == null)
+                var clientReadChannel = await Accept(_readChannel);
+
+                if (clientReadChannel != null && clientReadChannel.Available > 0)
                 {
-                    _clientReadChannel = await Accept(_readChannel);
-                }
-                
-                if (_clientReadChannel != null && _clientReadChannel.Available > 0)
-                {
-                    await new SocketChannelSelectionReader(this).Read(_clientReadChannel, new RawMessageBuilder(_messageBuffer.Capacity));
+                    await new SocketChannelSelectionReader(this).Read(clientReadChannel, new RawMessageBuilder(_messageBuffer.Capacity));
                 }
             }
             catch (Exception e)

--- a/src/Vlingo.Wire/Vlingo.Wire.csproj
+++ b/src/Vlingo.Wire/Vlingo.Wire.csproj
@@ -6,7 +6,7 @@
 
     <!-- NuGet Metadata -->
     <IsPackable>true</IsPackable>
-    <PackageVersion>0.3.11</PackageVersion>
+    <PackageVersion>0.3.12</PackageVersion>
     <PackageId>Vlingo.Wire</PackageId>
     <Authors>Vlingo</Authors>
     <Description>


### PR DESCRIPTION
`MulticastPublicherReader` was not accepting several client connections when listening on the port.