### PR TITLE
Fixes necessary for Vlingo.Directory and UDP

### DIFF
--- a/src/Vlingo.Wire/Message/RawMessage.cs
+++ b/src/Vlingo.Wire/Message/RawMessage.cs
@@ -138,7 +138,7 @@ namespace Vlingo.Wire.Message
             using (MemoryStream ms = new MemoryStream())
             {
                 buffer.CopyTo(ms);
-                Array.Copy(ms.ToArray(), 0, _bytes, 0, length);
+                Array.Copy(ms.ToArray(), 0, _bytes, _index, length);
             }
 
             _index = length;
@@ -154,7 +154,7 @@ namespace Vlingo.Wire.Message
                 // this copies from the actual position to the end of the stream so for the Array.Copy we need just to start at position = 0
                 // because the call to ms.GetBuffer() will bring the remaining buffer.
                 buffer.CopyTo(ms);
-                Array.Copy(ms.GetBuffer(), 0, _bytes, 0, length);
+                Array.Copy(ms.GetBuffer(), 0, _bytes, _index, length);
             }
 
             _index = length;

--- a/src/Vlingo.Wire/Multicast/MulticastPublisherReader.cs
+++ b/src/Vlingo.Wire/Multicast/MulticastPublisherReader.cs
@@ -279,7 +279,7 @@ namespace Vlingo.Wire.Multicast
         private void AcceptCallback(IAsyncResult ar)
         {
             // Get the socket that handles the client request.  
-            var listener = (Socket)ar.AsyncState;  
+            var listener = (Socket)ar.AsyncState;
             var clientChannel = listener.EndAccept(ar);  
             _clientReadChannels.Add(clientChannel);
             _acceptDone.Set();

--- a/src/Vlingo.Wire/Multicast/MulticastSubscriber.cs
+++ b/src/Vlingo.Wire/Multicast/MulticastSubscriber.cs
@@ -236,15 +236,13 @@ namespace Vlingo.Wire.Multicast
                 var bytesRead = channel.EndReceiveFrom(ar, ref _ipEndPoint);
                 if (bytesRead > 0)
                 {
+                    _buffer.Clear();
+                    _message.Reset();
                     _buffer.Write(buffer, 0, bytesRead);
                     _buffer.Flip();
                     _message.From(_buffer);
                     
                     _consumer.Consume(_message);
-                }
-                if (channel.Available > 0)
-                {
-                    channel.BeginReceiveFrom(buffer, 0, buffer.Length, SocketFlags.None, ref _ipEndPoint, ReceiveCallback, state);
                 }
             }
             catch (SocketException e)

--- a/src/Vlingo.Wire/Vlingo.Wire.csproj
+++ b/src/Vlingo.Wire/Vlingo.Wire.csproj
@@ -6,7 +6,7 @@
 
     <!-- NuGet Metadata -->
     <IsPackable>true</IsPackable>
-    <PackageVersion>0.5.0</PackageVersion>
+    <PackageVersion>0.5.1</PackageVersion>
     <PackageId>Vlingo.Wire</PackageId>
     <Authors>Vlingo</Authors>
     <Description>


### PR DESCRIPTION
- Fix MulticastSubscriber ReceiveCallback, not calling itself in a loop for UDP, reseting and clearing the buffer before each usage
- Bump version